### PR TITLE
Linux Arduino IDE compatibility patch

### DIFF
--- a/Z80.h
+++ b/Z80.h
@@ -12,7 +12,7 @@
 #ifndef _Z80_H
 #define _Z80_H
 
-#include "arduino.h"
+#include "Arduino.h"
 
 
 


### PR DESCRIPTION
When trying to compile CPM_Due in Linux you get "fatal error: arduino.h: No such file or directory". Linux filesystem is case sensitive and there is "Arduino.h" instead of "arduino.h". In Windows or Mac OS X there is still no difference between the two.
